### PR TITLE
Fix socket hang up with Node.js 19+

### DIFF
--- a/nodes/dlna-action.js
+++ b/nodes/dlna-action.js
@@ -1,5 +1,11 @@
+const http = require("http");
+const https = require("https");
 const MediaRenderer = require("../lib/MediaRenderer");
 const fetch = require("node-fetch").default;
+
+// Disable default HTTP keep-alive introduced in Node.js 19+
+http.globalAgent.keepAlive = false;
+https.globalAgent.keepAlive = false;
 
 module.exports = function(RED) {
     MediaRenderer.Scan();


### PR DESCRIPTION
## Summary
- disable HTTP keep-alive globally to avoid stale socket reuse

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687125c742a483248c1283237a5d9c5c